### PR TITLE
Implement several missing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ There is a chance there are currently issues with certain instructions that yet 
 | 0x9d                    | SBB L       |
 | 0x9e                    | SBB M       |
 | 0x9f                     | SBB A       |
-| 0xa9                    | XRA C       |
-| 0xaa                    | XRA D       |
-| 0xab                    | XRA E      |
-| 0xac                    | XRA H      |
-| 0xad                    | XRA L      |
-| 0xae                    | XRA M       |
 | 0xc7                    | RST 0       |
 | 0xcb                    | ?       |
 | 0xce                    | ACI D8       |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ There is a chance there are currently issues with certain instructions that yet 
 | Instruction Value | Instruction Name |
 | ------------------- | -------------------  |
 | 0x08                    | ?       |
-| 0x0b                    | DCX B       |
 | 0x10                    | ?       |
 | 0x17                    | RAL       |
 | 0x18                    | ?       |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ There is a chance there are currently issues with certain instructions that yet 
 
 | Instruction Value | Instruction Name |
 | ------------------- | -------------------  |
-| 0x02                    | STAX B       |
 | 0x08                    | ?       |
 | 0x0b                    | DCX B       |
 | 0x10                    | ?       |

--- a/Sources/Emul8080r/CPU.swift
+++ b/Sources/Emul8080r/CPU.swift
@@ -498,6 +498,24 @@ public final class CPU {
         case .xra_b:
             state.registers.a ^= state.registers.b
             updateLogicZSPC(Int(state.registers.a))
+        case .xra_c:
+            state.registers.c &= state.registers.c
+            updateLogicZSPC(Int(state.registers.c))
+        case .xra_d:
+            state.registers.d &= state.registers.d
+            updateLogicZSPC(Int(state.registers.d))
+        case .xra_e:
+            state.registers.e &= state.registers.e
+            updateLogicZSPC(Int(state.registers.e))
+        case .xra_h:
+            state.registers.h &= state.registers.h
+            updateLogicZSPC(Int(state.registers.h))
+        case .xra_l:
+            state.registers.l &= state.registers.l
+            updateLogicZSPC(Int(state.registers.l))
+        case .xra_m:
+            state.registers.a &= state.memory[m_address()]
+            updateLogicZSPC(Int(state.registers.a))
         case .xra_a:
             state.registers.a ^= state.registers.a
             updateLogicZSPC(Int(state.registers.a))

--- a/Sources/Emul8080r/CPU.swift
+++ b/Sources/Emul8080r/CPU.swift
@@ -125,6 +125,10 @@ public final class CPU {
         case .ldax_b_c:
             let address = Int(addressRegisterPair(state.registers.b, state.registers.c))
             state.registers.a = state.memory[address]
+        case .dcx_b_c:
+            let value = addressRegisterPair(state.registers.b, state.registers.c)
+            let (result, _) = value.subtractingReportingOverflow(1)
+            write(result, pair: .bc)
         case .inr_c:
             try increment(.c)
         case .dcr_c:

--- a/Sources/Emul8080r/CPU.swift
+++ b/Sources/Emul8080r/CPU.swift
@@ -31,17 +31,19 @@ public final class CPU {
 
     public weak var bus: IOBus?
 
-    public internal(set) var state = State8080()
-    public internal(set) var memory: [UInt8]
+    public internal(set) var state: State8080
 
-    public init(memory: [UInt8], systemClock: SystemClock) {
-        self.memory = memory
+    let safeMemoryBounds: Range<UInt8>?
+
+    public init(memory: [UInt8], systemClock: SystemClock, safeMemoryBounds: Range<UInt8>? = nil) {
+        self.state = State8080(memory: memory)
         self.systemClock = systemClock
+        self.safeMemoryBounds = safeMemoryBounds
     }
 
     public func load(_ data: [UInt8]) {
         for (offset, byte) in data.enumerated() {
-            memory[offset] = byte
+            state.memory[offset] = byte
         }
 
         disassembler = Disassembler(data: data)
@@ -80,19 +82,22 @@ public final class CPU {
         lastExecutionTime = now
     }
 
-    private func execute() throws -> Int {
-        guard state.pc < memory.count else {
+    func execute() throws -> Int {
+        guard state.pc < state.memory.count else {
             // End of program
             throw Error.programTerminated
         }
 
-        guard let code = OpCode(rawValue: memory[Int(state.pc)]) else {
-            throw Error.unknownCode(String(memory[Int(state.pc)], radix: 16))
+        guard let code = OpCode(rawValue: state.memory[Int(state.pc)]) else {
+            throw Error.unknownCode(String(state.memory[Int(state.pc)], radix: 16))
         }
 
         switch code {
         case .nop:
             break
+        case .stax_b_c:
+            let address = addressRegisterPair(state.registers.b, state.registers.c)
+            try write(state.registers.a, at: Int(address))
         case .lxi_b_c:
             writeImmediate(to: .bc)
         case .inx_b_c:
@@ -104,7 +109,7 @@ public final class CPU {
         case .dcr_b:
             try decrement(.b)
         case .mvi_b:
-            state.registers.b = memory[state.pc + 1]
+            state.registers.b = state.memory[state.pc + 1]
         case .rlc:
             let value = state.registers.a
             state.registers.a = ((value & 0x80) >> 7) | value << 1
@@ -119,13 +124,13 @@ public final class CPU {
             state.condition_bits.carry = UInt8(overflow)
         case .ldax_b_c:
             let address = Int(addressRegisterPair(state.registers.b, state.registers.c))
-            state.registers.a = memory[address]
+            state.registers.a = state.memory[address]
         case .inr_c:
             try increment(.c)
         case .dcr_c:
             try decrement(.c)
         case .mvi_c:
-            state.registers.c = memory[state.pc + 1]
+            state.registers.c = state.memory[state.pc + 1]
         case .rrc:
             let accumulator = state.registers.a
             state.registers.a = ((accumulator & 1) << 7) | accumulator >> 1
@@ -144,7 +149,7 @@ public final class CPU {
         case .dcr_d:
             try decrement(.d)
         case .mvi_d:
-            state.registers.d = memory[state.pc + 1]
+            state.registers.d = state.memory[state.pc + 1]
         case .dad_d_e:
             let de = addressRegisterPair(state.registers.d, state.registers.e)
             let hl = addressRegisterPair(state.registers.h, state.registers.l)
@@ -157,13 +162,13 @@ public final class CPU {
             try increment(.h)
         case .ldax_d_e:
             let address = Int(addressRegisterPair(state.registers.d, state.registers.e))
-            state.registers.a = memory[address]
+            state.registers.a = state.memory[address]
         case .dcx_d_e:
             let value = addressRegisterPair(state.registers.d, state.registers.e)
             let (result, _) = value.subtractingReportingOverflow(1)
             write(result, pair: .de)
         case .mvi_e:
-            state.registers.e = memory[state.pc + 1]
+            state.registers.e = state.memory[state.pc + 1]
         case .cma:
             state.registers.a = ~state.registers.a
         case .rar:
@@ -174,7 +179,7 @@ public final class CPU {
         case .lxi_h_l:
             writeImmediate(to: .hl)
         case .shld:
-            let address = Int(addressRegisterPair(memory[state.pc + 2], memory[state.pc + 1]))
+            let address = Int(addressRegisterPair(state.memory[state.pc + 2], state.memory[state.pc + 1]))
             try write(state.registers.l, at: address)
             try write(state.registers.h, at: address + 1)
         case .inx_h_l:
@@ -203,7 +208,7 @@ public final class CPU {
                 updateArithmeticZSPC(Int(result), overflow: overflow)
             }
         case .mvi_h:
-            state.registers.h = memory[state.pc + 1]
+            state.registers.h = state.memory[state.pc + 1]
         case .dad_h_l:
             let hl = addressRegisterPair(state.registers.h, state.registers.l)
             let (result, overflow) = hl.addingReportingOverflow(hl)
@@ -211,9 +216,9 @@ public final class CPU {
             write(result, pair: .hl)
             state.condition_bits.carry = UInt8(overflow)
         case .lhld:
-            let address = Int(addressRegisterPair(memory[state.pc + 2], memory[state.pc + 1]))
-            state.registers.l = memory[address]
-            state.registers.h = memory[address + 1]
+            let address = Int(addressRegisterPair(state.memory[state.pc + 2], state.memory[state.pc + 1]))
+            state.registers.l = state.memory[address]
+            state.registers.h = state.memory[address + 1]
         case .dcx_h_l:
             let value = addressRegisterPair(state.registers.h, state.registers.l)
             let (result, _) = value.subtractingReportingOverflow(1)
@@ -221,29 +226,29 @@ public final class CPU {
         case .inr_l:
             try increment(.l)
         case .mvi_l:
-            state.registers.l = memory[state.pc + 1]
+            state.registers.l = state.memory[state.pc + 1]
         case .lxi_sp:
-            state.sp = Int(addressRegisterPair(memory[state.pc + 2], memory[state.pc + 1]))
+            state.sp = Int(addressRegisterPair(state.memory[state.pc + 2], state.memory[state.pc + 1]))
         case .sta:
-            let address =  Int(addressRegisterPair(memory[state.pc + 2], memory[state.pc + 1]))
+            let address =  Int(addressRegisterPair(state.memory[state.pc + 2], state.memory[state.pc + 1]))
             try write(state.registers.a, at: address)
         case .inr_m:
             try increment(.m)
         case .dcr_m:
             try decrement(.m)
         case .mvi_m:
-            try write(memory[state.pc + 1], at: m_address())
+            try write(state.memory[state.pc + 1], at: m_address())
         case .stc:
             state.condition_bits.carry = 1
         case .lda:
-            let address = Int(addressRegisterPair(memory[state.pc + 2], memory[state.pc + 1]))
-            state.registers.a = memory[address]
+            let address = Int(addressRegisterPair(state.memory[state.pc + 2], state.memory[state.pc + 1]))
+            state.registers.a = state.memory[address]
         case .inr_a:
             try increment(.a)
         case .dcr_a:
             try decrement(.a)
         case .mvi_a:
-            state.registers.a = memory[state.pc + 1]
+            state.registers.a = state.memory[state.pc + 1]
         case .mov_b_b:
             break
         case .mov_b_c:
@@ -257,7 +262,7 @@ public final class CPU {
         case .mov_b_l:
             state.registers.b = state.registers.l
         case .mov_b_m:
-            state.registers.b = memory[m_address()]
+            state.registers.b = state.memory[m_address()]
         case .mov_b_a:
             state.registers.b = state.registers.a
         case .mov_c_b:
@@ -273,7 +278,7 @@ public final class CPU {
         case .mov_c_l:
             state.registers.c = state.registers.l
         case .mov_c_m:
-            state.registers.c = memory[m_address()]
+            state.registers.c = state.memory[m_address()]
         case .mov_c_a:
             state.registers.c = state.registers.a
         case .mov_d_b:
@@ -289,7 +294,7 @@ public final class CPU {
         case .mov_d_l:
             state.registers.d = state.registers.l
         case .mov_d_m:
-            state.registers.d = memory[m_address()]
+            state.registers.d = state.memory[m_address()]
         case .mov_d_a:
             state.registers.d = state.registers.a
         case .mov_e_b:
@@ -305,7 +310,7 @@ public final class CPU {
         case .mov_e_l:
             state.registers.e = state.registers.l
         case .mov_e_m:
-            state.registers.e = memory[m_address()]
+            state.registers.e = state.memory[m_address()]
         case .mov_e_a:
             state.registers.e = state.registers.a
         case .mov_h_b:
@@ -321,7 +326,7 @@ public final class CPU {
         case .mov_h_l:
             state.registers.h = state.registers.l
         case .mov_h_m:
-            state.registers.h = memory[m_address()]
+            state.registers.h = state.memory[m_address()]
         case .mov_h_a:
             state.registers.h = state.registers.a
         case .mov_l_b:
@@ -337,7 +342,7 @@ public final class CPU {
         case .mov_l_l:
             break
         case .mov_l_m:
-            state.registers.l = memory[m_address()]
+            state.registers.l = state.memory[m_address()]
         case .mov_l_a:
             state.registers.l = state.registers.a
         case .mov_m_b:
@@ -367,7 +372,7 @@ public final class CPU {
         case .mov_a_l:
             state.registers.a = state.registers.l
         case .mov_a_m:
-            state.registers.a = memory[m_address()]
+            state.registers.a = state.memory[m_address()]
         case .mov_a_a:
             break
         case .add_b:
@@ -395,7 +400,7 @@ public final class CPU {
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
         case .add_m:
-            let value = memory[m_address()]
+            let value = state.memory[m_address()]
             let (result, overflow) = state.registers.a.addingReportingOverflow(value)
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
@@ -456,7 +461,7 @@ public final class CPU {
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
         case .sub_m:
-            let (result, overflow) = state.registers.a.subtractingReportingOverflow(memory[m_address()])
+            let (result, overflow) = state.registers.a.subtractingReportingOverflow(state.memory[m_address()])
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
         case .sub_a:
@@ -481,7 +486,7 @@ public final class CPU {
             state.registers.a &= state.registers.l
             updateLogicZSPC(Int(state.registers.a))
         case .ana_m:
-            state.registers.a &= memory[m_address()]
+            state.registers.a &= state.memory[m_address()]
             updateLogicZSPC(Int(state.registers.a))
         case .ana_a:
             state.registers.a &= state.registers.a
@@ -511,7 +516,7 @@ public final class CPU {
             state.registers.a |= state.registers.l
             updateLogicZSPC(Int(state.registers.a))
         case .ora_m:
-            state.registers.a |= memory[m_address()]
+            state.registers.a |= state.memory[m_address()]
             updateLogicZSPC(Int(state.registers.a))
         case .ora_a:
             state.registers.a |= state.registers.a
@@ -529,7 +534,7 @@ public final class CPU {
         case .cmp_l:
             compare(Int(state.registers.l))
         case .cmp_m:
-            compare(Int(memory[m_address()]))
+            compare(Int(state.memory[m_address()]))
         case .cmp_a:
             compare(Int(state.registers.a))
         case .rnz:
@@ -557,7 +562,7 @@ public final class CPU {
         case .push_b:
             try push(high: state.registers.b, low: state.registers.c)
         case .adi:
-            let (result, overflow) = state.registers.a.addingReportingOverflow(memory[state.pc + 1])
+            let (result, overflow) = state.registers.a.addingReportingOverflow(state.memory[state.pc + 1])
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
         case .rz:
@@ -595,7 +600,7 @@ public final class CPU {
                 throw Error.missingIOHandler
             }
 
-            let port = memory[state.pc + 1]
+            let port = state.memory[state.pc + 1]
             bus.machineOUT(port: port, accumulator: state.registers.a)
         case .cnc:
             if state.condition_bits.carry == 0 {
@@ -605,7 +610,7 @@ public final class CPU {
         case .push_d:
             try push(high: state.registers.d, low: state.registers.e)
         case .sui:
-            let (result, overflow) = state.registers.a.subtractingReportingOverflow(memory[state.pc + 1])
+            let (result, overflow) = state.registers.a.subtractingReportingOverflow(state.memory[state.pc + 1])
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
         case .rc:
@@ -637,10 +642,10 @@ public final class CPU {
                 throw Error.missingIOHandler
             }
 
-            let device = memory[state.pc + 1]
+            let device = state.memory[state.pc + 1]
             state.registers.a = bus.machineIN(port: device)
         case .sbi:
-            let data = memory[state.pc + 1] + state.condition_bits.carry
+            let data = state.memory[state.pc + 1] + state.condition_bits.carry
             let (result, overflow) = state.registers.a.subtractingReportingOverflow(data)
             state.registers.a = result
             updateArithmeticZSPC(Int(state.registers.a), overflow: overflow)
@@ -651,8 +656,8 @@ public final class CPU {
         case .xthl:
             let l = state.registers.l
             let h = state.registers.h
-            let sp_0 = memory[state.sp]
-            let sp_1 = memory[state.sp + 1]
+            let sp_0 = state.memory[state.sp]
+            let sp_1 = state.memory[state.sp + 1]
 
             state.registers.l = sp_0
             state.registers.h = sp_1
@@ -662,7 +667,7 @@ public final class CPU {
         case .push_h:
             try push(high: state.registers.h, low: state.registers.l)
         case .ani:
-            state.registers.a &= memory[state.pc + 1]
+            state.registers.a &= state.memory[state.pc + 1]
             updateLogicZSPC(Int(state.registers.a))
         case .xchg:
             let h = state.registers.h
@@ -683,7 +688,7 @@ public final class CPU {
         case .push_psw:
             try push(high: state.registers.a, low: state.condition_bits.byte)
         case .ori:
-            state.registers.a |= memory[state.pc + 1]
+            state.registers.a |= state.memory[state.pc + 1]
         case .rm:
             if state.condition_bits.sign == 1 {
                 try ret()
@@ -697,7 +702,7 @@ public final class CPU {
         case .ei:
             state.inte = 0x01
         case .cpi:
-            let value = Int(memory[state.pc + 1])
+            let value = Int(state.memory[state.pc + 1])
             compare(value)
         }
 

--- a/Sources/Emul8080r/OpCode.swift
+++ b/Sources/Emul8080r/OpCode.swift
@@ -1,6 +1,7 @@
 public enum OpCode: UInt8, CustomStringConvertible {
     case nop = 0x00
     case lxi_b_c = 0x01
+    case stax_b_c = 0x02
     case inx_b_c = 0x03
     case inr_b = 0x04
     case dcr_b = 0x05
@@ -225,7 +226,7 @@ public enum OpCode: UInt8, CustomStringConvertible {
 
     public var size: Int {
         switch self {
-        case .nop, .inx_b_c, .inr_b, .dcr_b, .rlc, .dad_b_c, .ldax_b_c, .inr_c, .rar, .dcr_c, .rrc, .stax_d_e, .inx_d_e, .dad_d_e, .inr_h, .ldax_d_e, .dcx_d_e, .inr_d, .dcr_d, .inx_h_l, .inr_m, .daa, .dcr_a, .dad_h_l, .dcx_h_l, .inr_l, .cma, .dcr_m, .inr_a, .stc, .mov_b_b, .mov_b_c, .mov_b_d, .mov_b_e, .mov_b_h, .mov_b_l, .mov_b_m, .mov_b_a, .mov_c_b, .mov_c_c, .mov_c_d, .mov_c_e, .mov_c_h, .mov_c_l, .mov_c_m, .mov_c_a, .mov_d_b, .mov_d_c, .mov_d_d, .mov_d_e, .mov_d_h, .mov_d_l, .mov_d_m, .mov_d_a, .mov_e_b, .mov_e_c, .mov_e_d, .mov_e_e, .mov_e_h, .mov_e_l, .mov_e_m, .mov_e_a, .mov_h_b, .mov_h_c, .mov_h_d, .mov_h_e, .mov_h_h, .mov_h_l, .mov_h_m, .mov_h_a, .mov_l_b, .mov_l_c, .mov_l_d, .mov_l_e, .mov_l_h, .mov_l_l, .mov_l_m, .mov_l_a, .mov_m_b, .mov_m_c, .mov_m_d, .mov_m_e, .mov_m_h, .mov_m_l, .mov_m_a, .mov_a_b, .mov_a_c, .mov_a_d, .mov_a_e, .mov_a_h, .mov_a_l, .mov_a_m, .mov_a_a, .add_b, .add_c, .add_d, .add_e, .add_h, .add_l, .add_m, .add_a, .adc_b, .adc_c, .adc_d, .adc_e, .adc_h, .adc_l, .adc_m, .adc_a, .sub_b, .sub_c, .sub_d, .sub_e, .sub_h, .sub_l, .sub_m, .sub_a, .ana_b, .ana_c, .ana_d, .ana_e, .ana_h, .ana_l, .ana_m, .ana_a, .xra_b, .xra_a, .ora_b, .ora_c, .ora_d, .ora_e, .ora_h, .ora_l, .ora_m, .ora_a, .cmp_b, .cmp_c, .cmp_d, .cmp_e, .cmp_h, .cmp_l, .cmp_m, .cmp_a, .rnz, .pop_b, .push_b, .rz, .ret, .pop_d, .push_d, .rc, .rp, .rpo, .rpe, .rm, .rnc, .pop_h, .xthl, .push_h, .pchl, .xchg, .pop_psw, .di, .push_psw, .ei:
+        case .nop, .stax_b_c, .inx_b_c, .inr_b, .dcr_b, .rlc, .dad_b_c, .ldax_b_c, .inr_c, .rar, .dcr_c, .rrc, .stax_d_e, .inx_d_e, .dad_d_e, .inr_h, .ldax_d_e, .dcx_d_e, .inr_d, .dcr_d, .inx_h_l, .inr_m, .daa, .dcr_a, .dad_h_l, .dcx_h_l, .inr_l, .cma, .dcr_m, .inr_a, .stc, .mov_b_b, .mov_b_c, .mov_b_d, .mov_b_e, .mov_b_h, .mov_b_l, .mov_b_m, .mov_b_a, .mov_c_b, .mov_c_c, .mov_c_d, .mov_c_e, .mov_c_h, .mov_c_l, .mov_c_m, .mov_c_a, .mov_d_b, .mov_d_c, .mov_d_d, .mov_d_e, .mov_d_h, .mov_d_l, .mov_d_m, .mov_d_a, .mov_e_b, .mov_e_c, .mov_e_d, .mov_e_e, .mov_e_h, .mov_e_l, .mov_e_m, .mov_e_a, .mov_h_b, .mov_h_c, .mov_h_d, .mov_h_e, .mov_h_h, .mov_h_l, .mov_h_m, .mov_h_a, .mov_l_b, .mov_l_c, .mov_l_d, .mov_l_e, .mov_l_h, .mov_l_l, .mov_l_m, .mov_l_a, .mov_m_b, .mov_m_c, .mov_m_d, .mov_m_e, .mov_m_h, .mov_m_l, .mov_m_a, .mov_a_b, .mov_a_c, .mov_a_d, .mov_a_e, .mov_a_h, .mov_a_l, .mov_a_m, .mov_a_a, .add_b, .add_c, .add_d, .add_e, .add_h, .add_l, .add_m, .add_a, .adc_b, .adc_c, .adc_d, .adc_e, .adc_h, .adc_l, .adc_m, .adc_a, .sub_b, .sub_c, .sub_d, .sub_e, .sub_h, .sub_l, .sub_m, .sub_a, .ana_b, .ana_c, .ana_d, .ana_e, .ana_h, .ana_l, .ana_m, .ana_a, .xra_b, .xra_a, .ora_b, .ora_c, .ora_d, .ora_e, .ora_h, .ora_l, .ora_m, .ora_a, .cmp_b, .cmp_c, .cmp_d, .cmp_e, .cmp_h, .cmp_l, .cmp_m, .cmp_a, .rnz, .pop_b, .push_b, .rz, .ret, .pop_d, .push_d, .rc, .rp, .rpo, .rpe, .rm, .rnc, .pop_h, .xthl, .push_h, .pchl, .xchg, .pop_psw, .di, .push_psw, .ei:
             return 1
         case .mvi_b, .mvi_c, .mvi_d, .mvi_e, .mvi_h, .mvi_l, .mvi_m, .mvi_a, .sui, .adi, .out, .in, .sbi, .ani, .ori, .cpi:
             return 2
@@ -238,6 +239,8 @@ public enum OpCode: UInt8, CustomStringConvertible {
         switch self {
         case .nop:
             return "NOP"
+        case .stax_b_c:
+            return "STAX B C"
         case .lxi_b_c:
             return "LXI B C,#"
         case .inx_b_c:

--- a/Sources/Emul8080r/OpCode.swift
+++ b/Sources/Emul8080r/OpCode.swift
@@ -9,6 +9,7 @@ public enum OpCode: UInt8, CustomStringConvertible {
     case rlc = 0x07
     case dad_b_c = 0x09
     case ldax_b_c = 0x0a
+    case dcx_b_c = 0x0b
     case inr_c = 0x0c
     case dcr_c = 0x0d
     case mvi_c = 0x0e
@@ -226,7 +227,7 @@ public enum OpCode: UInt8, CustomStringConvertible {
 
     public var size: Int {
         switch self {
-        case .nop, .stax_b_c, .inx_b_c, .inr_b, .dcr_b, .rlc, .dad_b_c, .ldax_b_c, .inr_c, .rar, .dcr_c, .rrc, .stax_d_e, .inx_d_e, .dad_d_e, .inr_h, .ldax_d_e, .dcx_d_e, .inr_d, .dcr_d, .inx_h_l, .inr_m, .daa, .dcr_a, .dad_h_l, .dcx_h_l, .inr_l, .cma, .dcr_m, .inr_a, .stc, .mov_b_b, .mov_b_c, .mov_b_d, .mov_b_e, .mov_b_h, .mov_b_l, .mov_b_m, .mov_b_a, .mov_c_b, .mov_c_c, .mov_c_d, .mov_c_e, .mov_c_h, .mov_c_l, .mov_c_m, .mov_c_a, .mov_d_b, .mov_d_c, .mov_d_d, .mov_d_e, .mov_d_h, .mov_d_l, .mov_d_m, .mov_d_a, .mov_e_b, .mov_e_c, .mov_e_d, .mov_e_e, .mov_e_h, .mov_e_l, .mov_e_m, .mov_e_a, .mov_h_b, .mov_h_c, .mov_h_d, .mov_h_e, .mov_h_h, .mov_h_l, .mov_h_m, .mov_h_a, .mov_l_b, .mov_l_c, .mov_l_d, .mov_l_e, .mov_l_h, .mov_l_l, .mov_l_m, .mov_l_a, .mov_m_b, .mov_m_c, .mov_m_d, .mov_m_e, .mov_m_h, .mov_m_l, .mov_m_a, .mov_a_b, .mov_a_c, .mov_a_d, .mov_a_e, .mov_a_h, .mov_a_l, .mov_a_m, .mov_a_a, .add_b, .add_c, .add_d, .add_e, .add_h, .add_l, .add_m, .add_a, .adc_b, .adc_c, .adc_d, .adc_e, .adc_h, .adc_l, .adc_m, .adc_a, .sub_b, .sub_c, .sub_d, .sub_e, .sub_h, .sub_l, .sub_m, .sub_a, .ana_b, .ana_c, .ana_d, .ana_e, .ana_h, .ana_l, .ana_m, .ana_a, .xra_b, .xra_a, .ora_b, .ora_c, .ora_d, .ora_e, .ora_h, .ora_l, .ora_m, .ora_a, .cmp_b, .cmp_c, .cmp_d, .cmp_e, .cmp_h, .cmp_l, .cmp_m, .cmp_a, .rnz, .pop_b, .push_b, .rz, .ret, .pop_d, .push_d, .rc, .rp, .rpo, .rpe, .rm, .rnc, .pop_h, .xthl, .push_h, .pchl, .xchg, .pop_psw, .di, .push_psw, .ei:
+        case .nop, .stax_b_c, .inx_b_c, .inr_b, .dcr_b, .rlc, .dad_b_c, .ldax_b_c, .dcx_b_c, .inr_c, .rar, .dcr_c, .rrc, .stax_d_e, .inx_d_e, .dad_d_e, .inr_h, .ldax_d_e, .dcx_d_e, .inr_d, .dcr_d, .inx_h_l, .inr_m, .daa, .dcr_a, .dad_h_l, .dcx_h_l, .inr_l, .cma, .dcr_m, .inr_a, .stc, .mov_b_b, .mov_b_c, .mov_b_d, .mov_b_e, .mov_b_h, .mov_b_l, .mov_b_m, .mov_b_a, .mov_c_b, .mov_c_c, .mov_c_d, .mov_c_e, .mov_c_h, .mov_c_l, .mov_c_m, .mov_c_a, .mov_d_b, .mov_d_c, .mov_d_d, .mov_d_e, .mov_d_h, .mov_d_l, .mov_d_m, .mov_d_a, .mov_e_b, .mov_e_c, .mov_e_d, .mov_e_e, .mov_e_h, .mov_e_l, .mov_e_m, .mov_e_a, .mov_h_b, .mov_h_c, .mov_h_d, .mov_h_e, .mov_h_h, .mov_h_l, .mov_h_m, .mov_h_a, .mov_l_b, .mov_l_c, .mov_l_d, .mov_l_e, .mov_l_h, .mov_l_l, .mov_l_m, .mov_l_a, .mov_m_b, .mov_m_c, .mov_m_d, .mov_m_e, .mov_m_h, .mov_m_l, .mov_m_a, .mov_a_b, .mov_a_c, .mov_a_d, .mov_a_e, .mov_a_h, .mov_a_l, .mov_a_m, .mov_a_a, .add_b, .add_c, .add_d, .add_e, .add_h, .add_l, .add_m, .add_a, .adc_b, .adc_c, .adc_d, .adc_e, .adc_h, .adc_l, .adc_m, .adc_a, .sub_b, .sub_c, .sub_d, .sub_e, .sub_h, .sub_l, .sub_m, .sub_a, .ana_b, .ana_c, .ana_d, .ana_e, .ana_h, .ana_l, .ana_m, .ana_a, .xra_b, .xra_a, .ora_b, .ora_c, .ora_d, .ora_e, .ora_h, .ora_l, .ora_m, .ora_a, .cmp_b, .cmp_c, .cmp_d, .cmp_e, .cmp_h, .cmp_l, .cmp_m, .cmp_a, .rnz, .pop_b, .push_b, .rz, .ret, .pop_d, .push_d, .rc, .rp, .rpo, .rpe, .rm, .rnc, .pop_h, .xthl, .push_h, .pchl, .xchg, .pop_psw, .di, .push_psw, .ei:
             return 1
         case .mvi_b, .mvi_c, .mvi_d, .mvi_e, .mvi_h, .mvi_l, .mvi_m, .mvi_a, .sui, .adi, .out, .in, .sbi, .ani, .ori, .cpi:
             return 2
@@ -261,6 +262,8 @@ public enum OpCode: UInt8, CustomStringConvertible {
             return "DAD B C"
         case .ldax_b_c:
             return "LDAX B C"
+        case .dcx_b_c:
+            return "DCX B C"
         case .inr_c:
             return "INR C"
         case .rrc:

--- a/Sources/Emul8080r/OpCode.swift
+++ b/Sources/Emul8080r/OpCode.swift
@@ -143,6 +143,12 @@ public enum OpCode: UInt8, CustomStringConvertible {
     case ana_m = 0xa6
     case ana_a = 0xa7
     case xra_b = 0xa8
+    case xra_c = 0xa9
+    case xra_d = 0xaa
+    case xra_e = 0xab
+    case xra_h = 0xac
+    case xra_l = 0xad
+    case xra_m = 0xae
     case xra_a = 0xaf
     case ora_b = 0xb0
     case ora_c = 0xb1
@@ -227,7 +233,7 @@ public enum OpCode: UInt8, CustomStringConvertible {
 
     public var size: Int {
         switch self {
-        case .nop, .stax_b_c, .inx_b_c, .inr_b, .dcr_b, .rlc, .dad_b_c, .ldax_b_c, .dcx_b_c, .inr_c, .rar, .dcr_c, .rrc, .stax_d_e, .inx_d_e, .dad_d_e, .inr_h, .ldax_d_e, .dcx_d_e, .inr_d, .dcr_d, .inx_h_l, .inr_m, .daa, .dcr_a, .dad_h_l, .dcx_h_l, .inr_l, .cma, .dcr_m, .inr_a, .stc, .mov_b_b, .mov_b_c, .mov_b_d, .mov_b_e, .mov_b_h, .mov_b_l, .mov_b_m, .mov_b_a, .mov_c_b, .mov_c_c, .mov_c_d, .mov_c_e, .mov_c_h, .mov_c_l, .mov_c_m, .mov_c_a, .mov_d_b, .mov_d_c, .mov_d_d, .mov_d_e, .mov_d_h, .mov_d_l, .mov_d_m, .mov_d_a, .mov_e_b, .mov_e_c, .mov_e_d, .mov_e_e, .mov_e_h, .mov_e_l, .mov_e_m, .mov_e_a, .mov_h_b, .mov_h_c, .mov_h_d, .mov_h_e, .mov_h_h, .mov_h_l, .mov_h_m, .mov_h_a, .mov_l_b, .mov_l_c, .mov_l_d, .mov_l_e, .mov_l_h, .mov_l_l, .mov_l_m, .mov_l_a, .mov_m_b, .mov_m_c, .mov_m_d, .mov_m_e, .mov_m_h, .mov_m_l, .mov_m_a, .mov_a_b, .mov_a_c, .mov_a_d, .mov_a_e, .mov_a_h, .mov_a_l, .mov_a_m, .mov_a_a, .add_b, .add_c, .add_d, .add_e, .add_h, .add_l, .add_m, .add_a, .adc_b, .adc_c, .adc_d, .adc_e, .adc_h, .adc_l, .adc_m, .adc_a, .sub_b, .sub_c, .sub_d, .sub_e, .sub_h, .sub_l, .sub_m, .sub_a, .ana_b, .ana_c, .ana_d, .ana_e, .ana_h, .ana_l, .ana_m, .ana_a, .xra_b, .xra_a, .ora_b, .ora_c, .ora_d, .ora_e, .ora_h, .ora_l, .ora_m, .ora_a, .cmp_b, .cmp_c, .cmp_d, .cmp_e, .cmp_h, .cmp_l, .cmp_m, .cmp_a, .rnz, .pop_b, .push_b, .rz, .ret, .pop_d, .push_d, .rc, .rp, .rpo, .rpe, .rm, .rnc, .pop_h, .xthl, .push_h, .pchl, .xchg, .pop_psw, .di, .push_psw, .ei:
+        case .nop, .stax_b_c, .inx_b_c, .inr_b, .dcr_b, .rlc, .dad_b_c, .ldax_b_c, .dcx_b_c, .inr_c, .rar, .dcr_c, .rrc, .stax_d_e, .inx_d_e, .dad_d_e, .inr_h, .ldax_d_e, .dcx_d_e, .inr_d, .dcr_d, .inx_h_l, .inr_m, .daa, .dcr_a, .dad_h_l, .dcx_h_l, .inr_l, .cma, .dcr_m, .inr_a, .stc, .mov_b_b, .mov_b_c, .mov_b_d, .mov_b_e, .mov_b_h, .mov_b_l, .mov_b_m, .mov_b_a, .mov_c_b, .mov_c_c, .mov_c_d, .mov_c_e, .mov_c_h, .mov_c_l, .mov_c_m, .mov_c_a, .mov_d_b, .mov_d_c, .mov_d_d, .mov_d_e, .mov_d_h, .mov_d_l, .mov_d_m, .mov_d_a, .mov_e_b, .mov_e_c, .mov_e_d, .mov_e_e, .mov_e_h, .mov_e_l, .mov_e_m, .mov_e_a, .mov_h_b, .mov_h_c, .mov_h_d, .mov_h_e, .mov_h_h, .mov_h_l, .mov_h_m, .mov_h_a, .mov_l_b, .mov_l_c, .mov_l_d, .mov_l_e, .mov_l_h, .mov_l_l, .mov_l_m, .mov_l_a, .mov_m_b, .mov_m_c, .mov_m_d, .mov_m_e, .mov_m_h, .mov_m_l, .mov_m_a, .mov_a_b, .mov_a_c, .mov_a_d, .mov_a_e, .mov_a_h, .mov_a_l, .mov_a_m, .mov_a_a, .add_b, .add_c, .add_d, .add_e, .add_h, .add_l, .add_m, .add_a, .adc_b, .adc_c, .adc_d, .adc_e, .adc_h, .adc_l, .adc_m, .adc_a, .sub_b, .sub_c, .sub_d, .sub_e, .sub_h, .sub_l, .sub_m, .sub_a, .ana_b, .ana_c, .ana_d, .ana_e, .ana_h, .ana_l, .ana_m, .ana_a, .xra_b, .xra_c, .xra_d, .xra_e, .xra_h, .xra_l, .xra_m, .xra_a, .ora_b, .ora_c, .ora_d, .ora_e, .ora_h, .ora_l, .ora_m, .ora_a, .cmp_b, .cmp_c, .cmp_d, .cmp_e, .cmp_h, .cmp_l, .cmp_m, .cmp_a, .rnz, .pop_b, .push_b, .rz, .ret, .pop_d, .push_d, .rc, .rp, .rpo, .rpe, .rm, .rnc, .pop_h, .xthl, .push_h, .pchl, .xchg, .pop_psw, .di, .push_psw, .ei:
             return 1
         case .mvi_b, .mvi_c, .mvi_d, .mvi_e, .mvi_h, .mvi_l, .mvi_m, .mvi_a, .sui, .adi, .out, .in, .sbi, .ani, .ori, .cpi:
             return 2
@@ -526,6 +532,18 @@ public enum OpCode: UInt8, CustomStringConvertible {
             return "ANA A"
         case .xra_b:
             return "XRA B"
+        case .xra_c:
+            return "XRA C"
+        case .xra_d:
+            return "XRA D"
+        case .xra_e:
+            return "XRA E"
+        case .xra_h:
+            return "XRA H"
+        case .xra_l:
+            return "XRA L"
+        case .xra_m:
+            return "XRA M"
         case .xra_a:
             return "XRA A"
         case .ora_b:

--- a/Sources/Emul8080r/State.swift
+++ b/Sources/Emul8080r/State.swift
@@ -1,4 +1,4 @@
-public struct ConditionBits: Codable {
+public struct ConditionBits: Codable, Equatable {
     var zero: UInt8 = 0
     var sign: UInt8 = 0
     var parity: UInt8 = 0
@@ -10,7 +10,7 @@ public struct ConditionBits: Codable {
     }
 }
 
-public struct Registers: CustomStringConvertible, Codable {
+public struct Registers: CustomStringConvertible, Codable, Equatable {
     var a: UInt8 = 0
     var b: UInt8 = 0
     var c: UInt8 = 0
@@ -32,7 +32,7 @@ public struct Registers: CustomStringConvertible, Codable {
     }
 }
 
-public struct State8080: CustomStringConvertible, Codable {
+public struct State8080: CustomStringConvertible, Codable, Equatable {
     var registers = Registers()
 
     var sp: Int = 0
@@ -41,7 +41,11 @@ public struct State8080: CustomStringConvertible, Codable {
 
     var inte = UInt8(0) // Interrupts Enabled
 
-    public init() {}
+    var memory: [UInt8]
+
+    public init(memory: [UInt8]) {
+        self.memory = memory
+    }
 
     mutating func updateConditionBits(_ byte: UInt8) {
         var bits = String(byte, radix: 2).map { UInt8("\($0)")! }

--- a/Tests/Emul8080rTests/Emul8080rTests.swift
+++ b/Tests/Emul8080rTests/Emul8080rTests.swift
@@ -1,21 +1,15 @@
 import XCTest
 @testable import Emul8080r
 
-struct FakeClock: SystemClock {
-    func currentMicroseconds() -> Double {
-        0
-    }
-}
-
 final class Emul8080rTests: XCTestCase {
     func testBasicInstructionSequence() throws {
         // Increment BC, Increment BC, Add immediate value 0x01 to accumulator, Add C to accumulator
-        let instructions: [UInt8] = [OpCode.inx_b_c.rawValue,
+        let program: [UInt8] = [OpCode.inx_b_c.rawValue,
                                      OpCode.inx_b_c.rawValue,
                                      OpCode.adi.rawValue, 0x01,
                                      OpCode.add_c.rawValue]
 
-        let cpu = CPU(memory: instructions, systemClock: FakeClock())
+        let cpu = CPU(memory: program, systemClock: FakeClock())
 
         for _ in 0..<4 {
             _ = try cpu.execute()
@@ -27,13 +21,13 @@ final class Emul8080rTests: XCTestCase {
     }
 
     func test_STAX_bc() throws {
-        let instructions: [UInt8] = [OpCode.adi.rawValue, 0x01,
+        let program: [UInt8] = [OpCode.adi.rawValue, 0x01,
                                      OpCode.mvi_c.rawValue, 0x05,
                                      OpCode.stax_b_c.rawValue, 0x00]
         
-        let cpu = CPU(memory: instructions, systemClock: FakeClock())
+        let cpu = CPU(memory: program, systemClock: FakeClock())
 
-        var one = State8080(memory: instructions)
+        var one = State8080(memory: program)
         one.registers.a = 0x01
         one.pc = 2
 
@@ -54,19 +48,20 @@ final class Emul8080rTests: XCTestCase {
     }
 
     func test_DCX_bc() throws {
-        let instructions: [UInt8] = [OpCode.mvi_b.rawValue, 0x05,
+        let program: [UInt8] = [OpCode.mvi_b.rawValue, 0x05,
                                      OpCode.mvi_c.rawValue, 0x05,
                                      OpCode.dcx_b_c.rawValue]
 
-        let cpu = CPU(memory: instructions, systemClock: FakeClock())
+        let cpu = CPU(memory: program, systemClock: FakeClock())
 
-        var one = State8080(memory: instructions)
+        var one = State8080(memory: program)
         one.registers.b = 0x05
+        one.registers.c = 0x05
         one.pc = 2
 
         var two = one
         two.pc = 4
-        two.registers.c = 0x05
+
 
         var three = two
         three.pc = 5

--- a/Tests/Emul8080rTests/Emul8080rTests.swift
+++ b/Tests/Emul8080rTests/Emul8080rTests.swift
@@ -53,6 +53,34 @@ final class Emul8080rTests: XCTestCase {
         }
     }
 
+    func test_DCX_bc() throws {
+        let instructions: [UInt8] = [OpCode.mvi_b.rawValue, 0x05,
+                                     OpCode.mvi_c.rawValue, 0x05,
+                                     OpCode.dcx_b_c.rawValue]
+
+        let cpu = CPU(memory: instructions, systemClock: FakeClock())
+
+        var one = State8080(memory: instructions)
+        one.registers.b = 0x05
+        one.pc = 2
+
+        var two = one
+        two.pc = 4
+        two.registers.c = 0x05
+
+        var three = two
+        three.pc = 5
+        three.registers.b = 0x05
+        three.registers.c = 0x04
+
+        let expected = [one, two, three]
+
+        for i in 0..<3 {
+            _ = try cpu.execute()
+            XCTAssertEqual(cpu.state, expected[i])
+        }
+    }
+
     static var allTests = [
         ("testBasicInstructionSequence", testBasicInstructionSequence),
     ]

--- a/Tests/Emul8080rTests/Emul8080rTests.swift
+++ b/Tests/Emul8080rTests/Emul8080rTests.swift
@@ -5,9 +5,9 @@ final class Emul8080rTests: XCTestCase {
     func testBasicInstructionSequence() throws {
         // Increment BC, Increment BC, Add immediate value 0x01 to accumulator, Add C to accumulator
         let program: [UInt8] = [OpCode.inx_b_c.rawValue,
-                                     OpCode.inx_b_c.rawValue,
-                                     OpCode.adi.rawValue, 0x01,
-                                     OpCode.add_c.rawValue]
+                                OpCode.inx_b_c.rawValue,
+                                OpCode.adi.rawValue, 0x01,
+                                OpCode.add_c.rawValue]
 
         let cpu = CPU(memory: program, systemClock: FakeClock())
 
@@ -22,8 +22,8 @@ final class Emul8080rTests: XCTestCase {
 
     func test_STAX_bc() throws {
         let program: [UInt8] = [OpCode.adi.rawValue, 0x01,
-                                     OpCode.mvi_c.rawValue, 0x05,
-                                     OpCode.stax_b_c.rawValue, 0x00]
+                                OpCode.mvi_c.rawValue, 0x05,
+                                OpCode.stax_b_c.rawValue, 0x00]
         
         let cpu = CPU(memory: program, systemClock: FakeClock())
 
@@ -48,32 +48,89 @@ final class Emul8080rTests: XCTestCase {
     }
 
     func test_DCX_bc() throws {
-        let program: [UInt8] = [OpCode.mvi_b.rawValue, 0x05,
-                                     OpCode.mvi_c.rawValue, 0x05,
-                                     OpCode.dcx_b_c.rawValue]
+        let program: [UInt8] = populateRegisters(b: 0x05, c: 0x05) + [OpCode.dcx_b_c.rawValue]
 
         let cpu = CPU(memory: program, systemClock: FakeClock())
 
-        var one = State8080(memory: program)
-        one.registers.b = 0x05
-        one.registers.c = 0x05
-        one.pc = 2
+        var expected = State8080(memory: program)
+        expected.pc = 5
+        expected.registers.b = 0x05
+        expected.registers.c = 0x04
 
-        var two = one
-        two.pc = 4
-
-
-        var three = two
-        three.pc = 5
-        three.registers.b = 0x05
-        three.registers.c = 0x04
-
-        let expected = [one, two, three]
-
-        for i in 0..<3 {
-            _ = try cpu.execute()
-            XCTAssertEqual(cpu.state, expected[i])
+        while true {
+            do {
+                _ = try cpu.execute()
+            } catch CPU.Error.programTerminated {
+                break
+            } catch {
+                throw error
+            }
         }
+
+        XCTAssertEqual(cpu.state, expected)
+    }
+
+    func test_XRA_a() throws {
+        let program: [UInt8] = populateRegisters(a: 0x01) + [OpCode.xra_a.rawValue]
+
+        let cpu = CPU(memory: program, systemClock: FakeClock())
+
+        var expected = State8080(memory: program)
+        expected.registers.a = 0x00
+        expected.pc = 3
+        expected.condition_bits.parity = 1
+        expected.condition_bits.zero = 1
+
+        while true {
+            do {
+                _ = try cpu.execute()
+            } catch CPU.Error.programTerminated {
+                break
+            } catch {
+                throw error
+            }
+        }
+
+        XCTAssertEqual(cpu.state, expected)
+    }
+
+    func test_XRA_b() throws {
+        let program: [UInt8] = populateRegisters(a: 0x01, b: 0x0a) + [OpCode.xra_b.rawValue]
+
+        let cpu = CPU(memory: program, systemClock: FakeClock())
+
+        var expected = State8080(memory: program)
+        expected.registers.a = 0x0b
+        expected.registers.b = 0x0a
+        expected.pc = 5
+        expected.condition_bits.parity = 0
+        expected.condition_bits.zero = 0
+
+        while true {
+            do {
+                _ = try cpu.execute()
+            } catch CPU.Error.programTerminated {
+                break
+            } catch {
+                throw error
+            }
+        }
+
+        XCTAssertEqual(cpu.state, expected)
+    }
+
+    private func populateRegisters(a: UInt8? = nil, b: UInt8? = nil, c: UInt8? = nil, d: UInt8? = nil, e: UInt8? = nil, h: UInt8? = nil, l: UInt8? = nil) -> [UInt8] {
+        [
+            a.map { [OpCode.mvi_a.rawValue, $0] },
+            b.map { [OpCode.mvi_b.rawValue, $0] },
+            c.map { [OpCode.mvi_c.rawValue, $0] },
+            d.map { [OpCode.mvi_d.rawValue, $0] },
+            e.map { [OpCode.mvi_e.rawValue, $0] },
+            h.map { [OpCode.mvi_h.rawValue, $0] },
+            l.map { [OpCode.mvi_l.rawValue, $0] }
+        ]
+        .compactMap { $0 }
+        .flatMap { $0 }
     }
 
     static var allTests = [

--- a/Tests/Emul8080rTests/Emul8080rTests.swift
+++ b/Tests/Emul8080rTests/Emul8080rTests.swift
@@ -1,37 +1,56 @@
 import XCTest
 @testable import Emul8080r
 
-struct TestClock: SystemClock {
+struct FakeClock: SystemClock {
     func currentMicroseconds() -> Double {
-        var time = timeval(tv_sec: 0, tv_usec: 0)
-        gettimeofday(&time, nil)
-        return Double(time.tv_sec * __darwin_time_t(1E6) + __darwin_time_t(time.tv_usec))
+        0
     }
 }
 
 final class Emul8080rTests: XCTestCase {
-    func testBasicInstructionSequence() {
+    func testBasicInstructionSequence() throws {
         // Increment BC, Increment BC, Add immediate value 0x01 to accumulator, Add C to accumulator
-        let instructions: [UInt8] = [OpCode.inx_b_c.rawValue, OpCode.inx_b_c.rawValue, OpCode.adi.rawValue, 0x01, OpCode.add_c.rawValue]
+        let instructions: [UInt8] = [OpCode.inx_b_c.rawValue,
+                                     OpCode.inx_b_c.rawValue,
+                                     OpCode.adi.rawValue, 0x01,
+                                     OpCode.add_c.rawValue]
 
-        let cpu = CPU(memory: instructions, systemClock: TestClock())
+        let cpu = CPU(memory: instructions, systemClock: FakeClock())
 
-        while true {
-            do {
-                try cpu.start(interrupter: { () in 0 })
-            } catch {
-                guard case CPU.Error.programTerminated = error else {
-                    XCTFail("Unexpected error")
-                    return
-                }
-
-                break
-            }
+        for _ in 0..<4 {
+            _ = try cpu.execute()
         }
 
         XCTAssertEqual(cpu.state.registers.a, 3)
         XCTAssertEqual(cpu.state.registers.b, 0)
         XCTAssertEqual(cpu.state.registers.c, 2)
+    }
+
+    func test_STAX_bc() throws {
+        let instructions: [UInt8] = [OpCode.adi.rawValue, 0x01,
+                                     OpCode.mvi_c.rawValue, 0x05,
+                                     OpCode.stax_b_c.rawValue, 0x00]
+        
+        let cpu = CPU(memory: instructions, systemClock: FakeClock())
+
+        var one = State8080(memory: instructions)
+        one.registers.a = 0x01
+        one.pc = 2
+
+        var two = one
+        two.pc = 4
+        two.registers.c = 0x05
+
+        var three = two
+        three.pc = 5
+        three.memory[0x05] = 1
+
+        let expected = [one, two, three]
+
+        for i in 0..<3 {
+            _ = try cpu.execute()
+            XCTAssertEqual(cpu.state, expected[i])
+        }
     }
 
     static var allTests = [

--- a/Tests/Emul8080rTests/Fakes/FakeClock.swift
+++ b/Tests/Emul8080rTests/Fakes/FakeClock.swift
@@ -1,0 +1,8 @@
+import Foundation
+@testable import Emul8080r
+
+struct FakeClock: SystemClock {
+    func currentMicroseconds() -> Double {
+        0
+    }
+}


### PR DESCRIPTION
Implement:

* STAX_B_C (Store accumulator to the BC registers)
* DCX_B_C (Decrement register pair BC)
* All remaining XRA (XOR the value in the specified register with the accumulator)

Modify:

* Approach to unit testing, making state accessible internally to the module to make a comparison of pre-program/post-program unit testing possible.